### PR TITLE
Add _MODEL_PATH and _MODEL_VERSION ARGs to Dockerfile

### DIFF
--- a/app-api/Dockerfile
+++ b/app-api/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.10-slim
 
+ARG _MODEL_PATH
+ARG _MODEL_VERSION
+
 COPY requirements.txt .
 
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Also edited the trigger YAML to include:
```
- name: gcr.io/cloud-builders/docker
    env:
      - _MODEL_PATH=$_MODEL_PATH
      - _MODEL_VERSION=$_MODEL_VERSION
    args:
      - build
      - '--no-cache'
      - '--build-arg=_MODEL_PATH=${_MODEL_PATH}'
      - '--build-arg=_MODEL_VERSION=${_MODEL_VERSION}'
```